### PR TITLE
pfSense_ngctl_attach . when configuring supplicant mode

### DIFF
--- a/bin/pfatt.sh
+++ b/bin/pfatt.sh
@@ -142,6 +142,7 @@ elif [ "$EAP_MODE" = "supplicant" ] ; then
   /usr/bin/logger -st "pfatt" "cabling should look like this:"
   /usr/bin/logger -st "pfatt" "  ONT---[] [$ONT_IF]$HOST"
   /usr/bin/logger -st "pfatt" "creating vlan node and ngeth0 interface..."
+  /usr/local/bin/php -r "pfSense_ngctl_attach('.', '$ONT_IF');"
   /usr/sbin/ngctl mkpeer $ONT_IF: vlan lower downstream
   /usr/sbin/ngctl name $ONT_IF:lower vlan0
   /usr/sbin/ngctl mkpeer vlan0: eiface vlan0 ether


### PR DESCRIPTION
In pfSense 2.4.5, I found that without this line, all subsequent ngctl
commands produce "ngctl: send msg: No such file or directory"